### PR TITLE
Update Accessory Power For PLT-1B

### DIFF
--- a/Integrations/ESPHome/Battery.yaml
+++ b/Integrations/ESPHome/Battery.yaml
@@ -26,7 +26,8 @@ switch:
     pin: GPIO7
     name: "Accessory Power"
     id: accessory_power
-
+    restore_mode: ALWAYS_ON
+    setup_priority: 1100
 number:
   - platform: template
     name: "Run Duration"

--- a/Integrations/ESPHome/Battery.yaml
+++ b/Integrations/ESPHome/Battery.yaml
@@ -4,8 +4,8 @@ external_components:
 
 deep_sleep:
   id: deep_sleep_1
-  sleep_duration: 8h
-  run_duration: 30s
+  sleep_duration: 12h
+  run_duration: 60s
 
 sensor:
   - platform: max17048
@@ -32,7 +32,7 @@ number:
   - platform: template
     name: "Run Duration"
     id: deep_sleep_run_duration
-    min_value: 1
+    min_value: 20
     max_value: 800
     step: 1
     mode: box
@@ -58,7 +58,7 @@ number:
     update_interval: never
     optimistic: true
     restore_value: true
-    initial_value: 8
+    initial_value: 12
     icon: "mdi:arrow-collapse-right"
     entity_category: CONFIG
     unit_of_measurement: "h"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-plt-1
-  version: "24.10.24.1"
+  version: "24.10.25.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:


### PR DESCRIPTION
Version: 24.10.25.1

Adds:

Fixes:
- PLT-1B Startup Boot Loop

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In Core.yaml