### PR TITLE
Use addition instead of subtraction for offsets

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-plt-1
-  version: "24.10.25.1"
+  version: "24.11.1.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -231,12 +231,12 @@ sensor:
       name: "Air Temperature"
       id: aht_temperature
       filters:
-        - lambda: return x - id(aht_temperature_offset).state;
+        - lambda: return x + id(aht_temperature_offset).state;
     humidity:
       name: "Air Humidity"
       id: aht_humidity
       filters:
-        - lambda: return x - id(aht_humidity_offset).state;
+        - lambda: return x + id(aht_humidity_offset).state;
     update_interval: 60s
 
   - platform: adc


### PR DESCRIPTION
Version: 
PLT-1: 24.10.24.1
ESPHome: 2024.10.2

Adds:

Fixes:
Offset calculation.
 
Configuring offsets for Air Temp and Humidity sensors results in an output that is incorrect. Setting the inverse of the desired offset results in the expected adjustment to the sensor value.

ie. If the current temperature reading is 70 and I want to add an offset of -5, with the current formula the result would be 70 - -5 = 75. New formula would result in 70 + -5  = 65

Breaks:



Checks:
- [ ] Documentation Updated
- [x] Build Number Incremented In Core.yaml