### PR TITLE
Fix Project Names To Resolve Updates

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,7 +1,5 @@
 substitutions:
-  name: apollo-plt-1
-  version: "24.10.31.1"
-  device_description: ${name} made by Apollo Automation - version ${version}.
+  version: "24.11.6.1"
 
 esp32:
   board: esp32-c3-devkitm-1

--- a/Integrations/ESPHome/PLT-1.yaml
+++ b/Integrations/ESPHome/PLT-1.yaml
@@ -1,5 +1,5 @@
 esphome:
-  name: "${name}"
+  name: "apollo-plt-1"
   friendly_name: Apollo PLT-1
   comment: Apollo PLT-1
   name_add_mac_suffix: true

--- a/Integrations/ESPHome/PLT-1B.yaml
+++ b/Integrations/ESPHome/PLT-1B.yaml
@@ -1,13 +1,13 @@
 esphome:
-  name: "${name}"
-  friendly_name: Apollo PLT-1
-  comment: Apollo PLT-1
+  name: "apollo-plt-1b"
+  friendly_name: Apollo PLT-1B
+  comment: Apollo PLT-1B
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio
 
   project:
-    name: "ApolloAutomation.PLT-1"
+    name: "ApolloAutomation.PLT-1B"
     version: "${version}"
 
   min_version: 2024.2.0
@@ -73,7 +73,7 @@ wifi:
   on_disconnect:
     - ble.enable:
   ap:
-    ssid: "Apollo PLT1 Hotspot"
+    ssid: "Apollo PLT1B Hotspot"
 
 logger:
 

--- a/Integrations/ESPHome/PLT-1B_BLE.yaml
+++ b/Integrations/ESPHome/PLT-1B_BLE.yaml
@@ -1,13 +1,13 @@
 esphome:
-  name: "${name}"
-  friendly_name: Apollo PLT-1
-  comment: Apollo PLT-1
+  name: "apollo-plt-1b"
+  friendly_name: Apollo PLT-1B
+  comment: Apollo PLT-1B
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio
 
   project:
-    name: "ApolloAutomation.PLT-1"
+    name: "ApolloAutomation.PLT-1BBLE"
     version: "${version}"
 
   min_version: 2024.2.0
@@ -49,7 +49,7 @@ bluetooth_proxy:
 
 wifi:
   ap:
-    ssid: "Apollo PLT1 Hotspot"
+    ssid: "Apollo PLT1B Hotspot"
 
 logger:
 

--- a/Integrations/ESPHome/PLT-1B_BLE.yaml
+++ b/Integrations/ESPHome/PLT-1B_BLE.yaml
@@ -1,7 +1,7 @@
 esphome:
-  name: "apollo-plt-1b"
-  friendly_name: Apollo PLT-1B
-  comment: Apollo PLT-1B
+  name: "apollo-plt-1bble"
+  friendly_name: Apollo PLT-1BBLE
+  comment: Apollo PLT-1BBLE
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio

--- a/Integrations/ESPHome/PLT-1_BLE.yaml
+++ b/Integrations/ESPHome/PLT-1_BLE.yaml
@@ -7,7 +7,7 @@ esphome:
     board_build.flash_mode: dio
 
   project:
-    name: "ApolloAutomation.PLT-1"
+    name: "ApolloAutomation.PLT-1BLE"
     version: "${version}"
 
   min_version: 2024.2.0

--- a/Integrations/ESPHome/PLT-1_BLE.yaml
+++ b/Integrations/ESPHome/PLT-1_BLE.yaml
@@ -1,7 +1,7 @@
 esphome:
-  name: "${name}"
-  friendly_name: Apollo PLT-1
-  comment: Apollo PLT-1
+  name: "apollo-plt-1ble"
+  friendly_name: Apollo PLT-1BLE
+  comment: Apollo PLT-1BLE
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio


### PR DESCRIPTION
Version: 24.11.6.1

Adds:

Fixes:
- Update system having the wrong project names

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In Core.yaml