### PR TITLE
Initialise the AHT20 sensor late to reliably bring it up.

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -234,6 +234,7 @@ sensor:
       filters:
         - lambda: return x - id(aht_humidity_offset).state;
     update_interval: 60s
+    setup_priority: -100 # LATE
 
   - platform: adc
     pin: GPIO4


### PR DESCRIPTION
Fixes:
- Bring up the AHT20 sensor late in the boot process; seems to make it reliably come up.