### PR TITLE
Increase step resolution for voltage configs

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -120,7 +120,7 @@ number:
     initial_value: '1.55'
     optimistic: true
     update_interval: never
-    step: 0.1
+    step: 0.01
     mode: box
     restore_value: true
     entity_category: "CONFIG"
@@ -134,7 +134,7 @@ number:
     entity_category: "CONFIG"
     optimistic: true
     update_interval: never
-    step: 0.1
+    step: 0.01
     mode: box
     min_value: 0.0
     max_value: 5.0


### PR DESCRIPTION
prior to this change, we were unable to set the wet or dry voltages to two decimal places.

Version:

Adds:

Fixes:
ability to set wet and dry voltages to two decimal places.

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In Core.yaml