### PR TITLE
[wifi_info] Add IP address text sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -355,7 +355,7 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
-      id: wifi_ip
+      entity_category: "diagnostic"
 
 script:
   - id: statusCheck

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -355,6 +355,7 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
+      id: wifi_ip
       entity_category: "diagnostic"
 
 script:


### PR DESCRIPTION
Version: 25.8.6.1

## What does this implement/fix?

Adds the device's current IP address as a diagnostic text sensor in Home Assistant.

This makes it easy to identify and connect to individual PLT-1/PLT-1B devices on the network without having to check the router.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page