### PR TITLE
[version] Add ESPHome and Apollo firmware version sensors

### DIFF
--- a/Integrations/ESPHome/Battery.yaml
+++ b/Integrations/ESPHome/Battery.yaml
@@ -62,3 +62,4 @@ script:
       - component.update: sys_uptime
       - component.update: soil_adc
       - component.update: max_17048
+      - component.update: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -366,6 +366,7 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 script:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -351,6 +351,12 @@ switch:
                   id(deep_sleep_1).allow_deep_sleep();
 
 
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+
 script:
   - id: statusCheck
     then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -360,6 +360,7 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
+    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -356,6 +356,16 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 script:
   - id: statusCheck

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -360,7 +360,6 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
-    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/NonBattery.yaml
+++ b/Integrations/ESPHome/NonBattery.yaml
@@ -34,3 +34,4 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: soil_adc
+      - component.update: apollo_firmware_version


### PR DESCRIPTION
Version: 25.8.6.1

## What does this implement/fix?

Adds two diagnostic text sensors to Home Assistant:

- **ESPHome Version** — shows the running ESPHome version (timestamp hidden)
- **Apollo Firmware Version** — shows the Apollo firmware version string from the `version` substitution

Both sensors have `entity_category: diagnostic` so they appear in the device diagnostics panel rather than the main dashboard.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page