### PR TITLE
[api] Rename services to actions

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -351,6 +351,12 @@ switch:
                   id(deep_sleep_1).allow_deep_sleep();
 
 
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+
 script:
   - id: statusCheck
     then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -10,8 +10,8 @@ esp32:
        enable_lwip_assert: false
 
 api:
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -356,6 +356,16 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 script:
   - id: statusCheck


### PR DESCRIPTION
Version: 25.8.6.1

## What does this implement/fix?

ESPHome renamed the `services`/`service` keywords to `actions`/`action` in newer versions. This updates the `play_buzzer` API entry in Core.yaml to use the current syntax.

> **Breaking change:** Any Home Assistant automations or scripts that call `play_buzzer` as a service (e.g. `esphome.apollo_plt_1_play_buzzer`) must be updated to use the new action syntax after flashing this firmware.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page