### PR TITLE
[esphome] Modernise board spec, web server v3, remove legacy options

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -351,6 +351,12 @@ switch:
                   id(deep_sleep_1).allow_deep_sleep();
 
 
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+
 script:
   - id: statusCheck
     then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -10,8 +10,8 @@ esp32:
        enable_lwip_assert: false
 
 api:
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -2,7 +2,8 @@ substitutions:
   version: "25.8.6.1"
 
 esp32:
-  board: esp32-c3-devkitm-1
+  variant: esp32c3
+  flash_size: 4MB
   framework:
     type: esp-idf
     advanced:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -356,6 +356,16 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 script:
   - id: statusCheck

--- a/Integrations/ESPHome/PLT-1.yaml
+++ b/Integrations/ESPHome/PLT-1.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo PLT-1
   comment: Apollo PLT-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.PLT-1"
     version: "${version}"
@@ -48,6 +45,7 @@ esp32_improv:
 
 web_server:
   port: 80
+  version: 3
 
 ota:
   - platform: esphome
@@ -67,11 +65,6 @@ update:
     source: https://apolloautomation.github.io/PLT-1/firmware/manifest.json
 
 wifi:
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo PLT1 Hotspot"
 

--- a/Integrations/ESPHome/PLT-1B.yaml
+++ b/Integrations/ESPHome/PLT-1B.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo PLT-1B
   comment: Apollo PLT-1B
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.PLT-1B"
     version: "${version}"
@@ -60,6 +57,7 @@ safe_mode:
 
 web_server:
   port: 80
+  version: 3
 
 update:
   - platform: http_request
@@ -68,11 +66,6 @@ update:
     source: https://apolloautomation.github.io/PLT-1/firmware-b/manifest.json
 
 wifi:
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo PLT1B Hotspot"
 

--- a/Integrations/ESPHome/PLT-1B_BLE.yaml
+++ b/Integrations/ESPHome/PLT-1B_BLE.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo PLT-1BBLE
   comment: Apollo PLT-1BBLE
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.PLT-1BBLE"
     version: "${version}"

--- a/Integrations/ESPHome/PLT-1B_Minimal.yaml
+++ b/Integrations/ESPHome/PLT-1B_Minimal.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo PLT-1B Minimal
   comment: Apollo PLT-1B Minimal
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.PLT-1B_Minimal"
     version: "${version}"
@@ -50,6 +47,7 @@ ota:
 
 web_server:
   port: 80
+  version: 3
 
 wifi:
   ap:

--- a/Integrations/ESPHome/PLT-1_BLE.yaml
+++ b/Integrations/ESPHome/PLT-1_BLE.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo PLT-1BLE
   comment: Apollo PLT-1BLE
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.PLT-1BLE"
     version: "${version}"

--- a/Integrations/ESPHome/PLT-1_Minimal.yaml
+++ b/Integrations/ESPHome/PLT-1_Minimal.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo PLT-1 Minimal
   comment: Apollo PLT-1 Minimal
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.PLT-1_Minimal"
     version: "${version}"
@@ -49,6 +46,7 @@ ota:
 
 web_server:
   port: 80
+  version: 3
 
 wifi:
   ap:


### PR DESCRIPTION
Version: 25.8.6.1

## What does this implement/fix?

A set of non-breaking modernisation changes across all PLT-1 and PLT-1B firmware variants:

**`Core.yaml`**
- Replace deprecated `board: esp32-c3-devkitm-1` with explicit `variant: esp32c3` + `flash_size: 4MB` — the current recommended way to target ESP32-C3 hardware with ESP-IDF

**All device YAMLs** (`PLT-1`, `PLT-1B`, `PLT-1_BLE`, `PLT-1B_BLE`, `PLT-1_Minimal`, `PLT-1B_Minimal`)
- Remove `platformio_options: board_build.flash_mode: dio` — no longer needed once the variant/flash_size spec is used

**`PLT-1.yaml` and `PLT-1B.yaml`**
- Enable web server version 3 (`version: 3`) for the modern ESPHome dashboard UI
- Remove legacy `wifi: on_connect`/`on_disconnect` BLE hooks — no longer required

**`PLT-1_Minimal.yaml` and `PLT-1B_Minimal.yaml`**
- Enable web server version 3 (`version: 3`)

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page