### PR TITLE
[wifi_info] Add entity_category diagnostic to IP address sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -357,6 +357,7 @@ text_sensor:
     ip_address:
       name: "IP Address"
       id: wifi_ip
+      entity_category: "diagnostic"
   - platform: version
     name: "ESPHome Version"
     hide_timestamp: true


### PR DESCRIPTION
## What does this implement/fix?

Adds `entity_category: "diagnostic"` to the `wifi_info` IP address text sensor in `Core.yaml`.

This was missing from the original implementation — without it the IP address sensor appears in the main entity list rather than being grouped under Diagnostics in Home Assistant.

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)

## Checklist:

- [x] The code change has been tested and works locally