### PR TITLE
Add configurable update interval for LTR390 sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -68,6 +68,10 @@ globals:
     restore_value: no
     type: bool
     initial_value: "false"
+  - id: ltr390_last_update
+    restore_value: no
+    type: uint32_t
+    initial_value: '0'
 
 
 captive_portal:
@@ -142,6 +146,19 @@ number:
     mode: box
     min_value: 0.0
     max_value: 5.0
+  - platform: template
+    name: LTR390 Update Interval
+    id: ltr390_update_interval
+    restore_value: true
+    initial_value: 60
+    min_value: 1
+    max_value: 300
+    entity_category: "CONFIG"
+    unit_of_measurement: "s"
+    optimistic: true
+    update_interval: never
+    step: 1
+    mode: box
 
 binary_sensor:
   - platform: status
@@ -286,13 +303,13 @@ sensor:
 
   - platform: ltr390
     id: ltr_390
+    update_interval: never
     light:
       name: "LTR390 Light"
       id: ltr390light
     uv_index:
       name: "LTR390 UV Index"
       id: ltr390uvindex
-    update_interval: 60s
 
 light:
   - platform: esp32_rmt_led_strip
@@ -492,7 +509,23 @@ script:
                 - light.turn_off:
                     id: rgb_light
 
+interval:
+  - interval: 1s
+    then:
+      - lambda: |-
+          uint32_t current_time = millis() / 1000;
+          uint32_t last_update = id(ltr390_last_update);
+          uint32_t interval = (uint32_t)id(ltr390_update_interval).state;
 
+          // Immediate update on boot (when last_update is still 0)
+          if (last_update == 0 && current_time > 0) {
+            id(ltr_390).update();
+            id(ltr390_last_update) = current_time;
+            return;
+          }
 
-
-
+          // Check if enough time has passed
+          if (current_time - last_update >= interval) {
+            id(ltr_390).update();
+            id(ltr390_last_update) = current_time;
+          }


### PR DESCRIPTION
## Summary

This PR implements the configurable update interval for the LTR390 light sensor, mirroring the same change made in MSR-2 PR #56.

- **LTR390 Update Interval**: Allows users to adjust the sensor update frequency from the default 60 seconds to any value between 1-300 seconds

## Changes

### Number Input Added
- `LTR390 Update Interval` - Configurable sensor polling rate (1-300 seconds, default: 60s)

### Sensor Configuration Updates
- Set LTR390 `update_interval` to `never` (disables automatic polling)
- Added global variable `ltr390_last_update` to track last sensor update time
- Added `interval` component that runs every 1 second to check if configured interval has elapsed
- Manually triggers sensor update via `component.update()` when needed

## Technical Details

**Why use interval component?**
ESPHome sensor platforms don't support templatable `update_interval` parameters. Attempting to use a lambda for `update_interval` results in compilation error: "This option is not templatable!"

**How it works:**
1. LTR390 sensor automatic updates are disabled (`update_interval: never`)
2. A 1-second interval checks elapsed time since last update
3. When configured interval is reached, manually triggers `id(ltr_390).update()`
4. Tracks update time in global variable for next interval calculation

**The setting:**
- Uses ESPHome template number platform
- Is categorized as CONFIG entity for proper grouping in the web UI
- Persists values across device reboots (`restore_value: true`)
- Updates take effect immediately without reboot

## Benefits

Users running the PLT-1 or PLT-1B without deep sleep can now adjust the LTR390 sensor update frequency without:
- Editing YAML configuration files
- Recompiling firmware
- Reflashing the device

## Compatibility

- Backward compatible (defaults to 60s matching current behavior)
- The existing `reportAllValues` script's `component.update: ltr_390` call remains fully compatible with `update_interval: never`
- Deep-sleep users: no meaningful impact — sensor still updates once per wake cycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LTR390 light and UV sensor now features a user-configurable update interval, allowing adjustment between 1-300 seconds (default 60 seconds). This enables customization of reading frequency based on your application needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->