### PR TITLE
Fix Apollo Firmware Version sensor showing unknown

### DIFF
--- a/Integrations/ESPHome/Battery.yaml
+++ b/Integrations/ESPHome/Battery.yaml
@@ -62,4 +62,6 @@ script:
       - component.update: sys_uptime
       - component.update: soil_adc
       - component.update: max_17048
-      - component.update: apollo_firmware_version
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"

--- a/Integrations/ESPHome/Battery.yaml
+++ b/Integrations/ESPHome/Battery.yaml
@@ -62,6 +62,3 @@ script:
       - component.update: sys_uptime
       - component.update: soil_adc
       - component.update: max_17048
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -382,8 +382,7 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    lambda: |-
-      return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 script:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -384,7 +384,6 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
-    update_interval: never
     entity_category: "diagnostic"
 
 script:

--- a/Integrations/ESPHome/NonBattery.yaml
+++ b/Integrations/ESPHome/NonBattery.yaml
@@ -34,4 +34,6 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: soil_adc
-      - component.update: apollo_firmware_version
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"

--- a/Integrations/ESPHome/NonBattery.yaml
+++ b/Integrations/ESPHome/NonBattery.yaml
@@ -34,6 +34,3 @@ script:
       - component.update: sys_esp_temperature
       - component.update: sys_uptime
       - component.update: soil_adc
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"

--- a/Integrations/ESPHome/PLT-1.yaml
+++ b/Integrations/ESPHome/PLT-1.yaml
@@ -11,6 +11,9 @@ esphome:
   on_boot:
     - priority: 800.0
       then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
         - lambda: |-
             id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
             id(deep_sleep_1).set_run_duration(90 * 1000);

--- a/Integrations/ESPHome/PLT-1.yaml
+++ b/Integrations/ESPHome/PLT-1.yaml
@@ -25,7 +25,6 @@ esphome:
                   id(deep_sleep_1).prevent_deep_sleep();
     - priority: 500
       then:
-        - logger.log: "Apollo: About to publish firmware version"
         - text_sensor.template.publish:
             id: apollo_firmware_version
             state: "${version}"

--- a/Integrations/ESPHome/PLT-1.yaml
+++ b/Integrations/ESPHome/PLT-1.yaml
@@ -11,9 +11,6 @@ esphome:
   on_boot:
     - priority: 800.0
       then:
-        - text_sensor.template.publish:
-            id: apollo_firmware_version
-            state: "${version}"
         - lambda: |-
             id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
             id(deep_sleep_1).set_run_duration(90 * 1000);
@@ -25,7 +22,12 @@ esphome:
             then:
               - lambda: |- 
                   ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
-                  id(deep_sleep_1).prevent_deep_sleep(); 
+                  id(deep_sleep_1).prevent_deep_sleep();
+    - priority: 600
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
     - priority: -10
       then:
         - if:

--- a/Integrations/ESPHome/PLT-1.yaml
+++ b/Integrations/ESPHome/PLT-1.yaml
@@ -25,6 +25,7 @@ esphome:
                   id(deep_sleep_1).prevent_deep_sleep();
     - priority: 500
       then:
+        - logger.log: "Apollo: About to publish firmware version"
         - text_sensor.template.publish:
             id: apollo_firmware_version
             state: "${version}"

--- a/Integrations/ESPHome/PLT-1.yaml
+++ b/Integrations/ESPHome/PLT-1.yaml
@@ -23,7 +23,7 @@ esphome:
               - lambda: |- 
                   ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
                   id(deep_sleep_1).prevent_deep_sleep();
-    - priority: 600
+    - priority: 500
       then:
         - text_sensor.template.publish:
             id: apollo_firmware_version

--- a/Integrations/ESPHome/PLT-1B.yaml
+++ b/Integrations/ESPHome/PLT-1B.yaml
@@ -23,6 +23,11 @@ esphome:
               - lambda: |- 
                   ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
                   id(deep_sleep_1).prevent_deep_sleep();
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
     - priority: -10
       then:
         - if:

--- a/Integrations/ESPHome/PLT-1B_BLE.yaml
+++ b/Integrations/ESPHome/PLT-1B_BLE.yaml
@@ -11,6 +11,9 @@ esphome:
   on_boot:
     priority: 500
     then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
       - lambda: |-
           id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
           id(deep_sleep_1).set_run_duration(90 * 1000);

--- a/Integrations/ESPHome/PLT-1B_Minimal.yaml
+++ b/Integrations/ESPHome/PLT-1B_Minimal.yaml
@@ -23,6 +23,11 @@ esphome:
               - lambda: |- 
                   ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
                   id(deep_sleep_1).prevent_deep_sleep();
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
     - priority: -10
       then:
         - if:

--- a/Integrations/ESPHome/PLT-1_BLE.yaml
+++ b/Integrations/ESPHome/PLT-1_BLE.yaml
@@ -11,6 +11,9 @@ esphome:
   on_boot:
     priority: 500
     then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
       - lambda: |-
           id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
           id(deep_sleep_1).set_run_duration(90 * 1000);

--- a/Integrations/ESPHome/PLT-1_Minimal.yaml
+++ b/Integrations/ESPHome/PLT-1_Minimal.yaml
@@ -23,6 +23,11 @@ esphome:
               - lambda: |- 
                   ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
                   id(deep_sleep_1).prevent_deep_sleep(); 
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
     - priority: -10
       then:
         - if:


### PR DESCRIPTION
Version:

## What does this implement/fix?

Fixes Apollo Firmware Version text sensor showing "unknown" in Home Assistant.

- Replaced `component.update` with `text_sensor.template.publish` for the version sensor in `reportAllValues` script (Battery.yaml and NonBattery.yaml)
- Removed `update_interval: never` so the lambda also fires periodically (every 60s) as a fallback

The root cause is that ESPHome's `component.update` action silently skips execution when the component's `is_ready()` check fails (see `UpdateComponentAction::play()` in `esphome/core/base_automation.h`). The `text_sensor.template.publish` action calls `publish_state()` directly without this guard.

Same fix as ApolloAutomation/AIR-1#87

## Types of changes

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apollo Firmware Version sensor no longer emits values via the prior automatic update mechanism.
* **New Features**
  * PLT-1 family devices now explicitly publish the firmware version at device boot so the version is available on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->