### PR TITLE
Unified firmware: runtime Bluetooth Proxy switch + Stable/Beta channel OTA

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,0 +1,103 @@
+name: Build and Publish Beta
+
+# Builds PLT-1 firmware from the beta branch and publishes it as assets on a
+# rolling "beta-fw" pre-release. The on-device "Firmware Channel" select points
+# OTA updates at these assets. Stable firmware is built/published separately
+# by build.yml (push to main -> GitHub Pages).
+
+on:
+  push:
+    branches: [beta]
+    paths:
+      - 'Integrations/ESPHome/**'
+  workflow_dispatch:
+
+# Least privilege: read-only by default; only publish-beta is elevated to write.
+permissions:
+  contents: read
+
+jobs:
+  version:
+    name: Read version
+    runs-on: ubuntu-latest
+    outputs:
+      v: ${{ steps.read.outputs.v }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - id: read
+        run: |
+          v=$(awk '/substitutions:/ {f=1} f && /version:/ {print $2; exit}' \
+            Integrations/ESPHome/Core.yaml | tr -d '"')
+          echo "v=$v" >> "$GITHUB_OUTPUT"
+          echo "Beta version: $v"
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: version
+    strategy:
+      matrix:
+        include:
+          # Beta serves OTA updates only, so it builds the end-user Minimal
+          # images, not the first-flash improv images.
+          - { yaml: Integrations/ESPHome/beta-channel/PLT-1_Minimal.yaml,  name: firmware-beta }
+          - { yaml: Integrations/ESPHome/beta-channel/PLT-1B_Minimal.yaml, name: firmware-b-beta }
+    uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df # 2026.4.1
+    with:
+      files: ${{ matrix.yaml }}
+      esphome-version: stable
+      combined-name: ${{ matrix.name }}
+      release-version: ${{ needs.version.outputs.v }}
+
+  publish-beta:
+    name: Publish beta release assets
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: fw
+          pattern: firmware*
+
+      - name: Ensure rolling 'beta-fw' pre-release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view beta-fw -R "${{ github.repository }}" >/dev/null 2>&1 \
+            || gh release create beta-fw -R "${{ github.repository }}" \
+                 --prerelease --title "Beta (rolling)" \
+                 --notes "Latest PLT-1 beta firmware. Auto-updated on every push to the beta branch."
+
+      - name: Rewrite manifests to absolute URLs and upload assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE="https://github.com/${{ github.repository }}/releases/download/beta-fw"
+          # Manifest names match the on-device variant_slug: "" and "-b".
+          declare -A DIRS=( [""]=firmware-beta ["-b"]=firmware-b-beta )
+          for v in "" "-b"; do
+            src="fw/${DIRS[$v]}"
+            man=$(find "$src" -name manifest.json | head -1)
+            if [ -z "$man" ]; then
+              echo "::error::manifest.json not found for ${DIRS[$v]}"
+              exit 1
+            fi
+            echo "Rewriting $man"
+            # Make ota.path and parts[].path absolute release-asset URLs so the
+            # device never has to resolve a relative path against a redirect.
+            # The two variants have distinct device names, so bin filenames
+            # don't collide in the flat release-asset namespace.
+            jq --arg base "$BASE" '
+              .builds[0].ota.path = ($base + "/" + (.builds[0].ota.path | sub(".*/"; "")))
+              | .builds[0].parts |= map(.path = ($base + "/" + (.path | sub(".*/"; ""))))
+            ' "$man" > "manifest$v.json"
+            cat "manifest$v.json"
+            gh release upload beta-fw "manifest$v.json" -R "${{ github.repository }}" --clobber
+            find "$src" -name '*.bin' -print -exec \
+              gh release upload beta-fw {} -R "${{ github.repository }}" --clobber \;
+          done
+          echo "Beta assets published."

--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -101,3 +101,14 @@ jobs:
               gh release upload beta-fw {} -R "${{ github.repository }}" --clobber \;
           done
           echo "Beta assets published."
+
+      - name: Point beta-fw tag at the built commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # gh release create tags default-branch HEAD, and uploads never move
+          # the tag, so without this the release's source commit drifts away
+          # from the assets actually published.
+          gh api -X PATCH "repos/${{ github.repository }}/git/refs/tags/beta-fw" \
+            -f sha="${{ github.sha }}" -F force=true
+          echo "beta-fw -> ${{ github.sha }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-and-publish:
-    uses: ApolloAutomation/Workflows/.github/workflows/build.yml@main
+    uses: ApolloAutomation/Workflows/.github/workflows/build.yml@430d90dc695c6f7d1075c4e4a0df4b13a6496252 # main 2026-07-23
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,16 @@ jobs:
       pull-requests: write
     with:
       device-name: plt-1
+      # The Minimal yamls are the end-user images served at firmware/ and
+      # firmware-b/ (OTA updates and dashboard adoption). The improv images
+      # move to *-factory/ and are only used for first flashes via the web
+      # installer.
       yaml-files: |
+        Integrations/ESPHome/PLT-1_Minimal.yaml
+        Integrations/ESPHome/PLT-1B_Minimal.yaml
         Integrations/ESPHome/PLT-1.yaml
         Integrations/ESPHome/PLT-1B.yaml
-      firmware-names: "1:firmware,1B:firmware-b"
+      firmware-names: "1_Minimal:firmware,1B_Minimal:firmware-b,1:firmware-factory,1B:firmware-b-factory"
       core-yaml-path: Integrations/ESPHome/Core.yaml
       esphome-version: stable
       # Bypass check if manually triggered with bypass option

--- a/Integrations/ESPHome/.gitignore
+++ b/Integrations/ESPHome/.gitignore
@@ -3,3 +3,4 @@
 # You can modify this file to suit your needs.
 /.esphome/
 /secrets.yaml
+beta-channel/.esphome/

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,41 @@
 substitutions:
-  version: "26.3.2.1"
+  version: "26.7.12.1"
+  # Firmware variant identity: overridden to "-b" by the PLT-1B images so
+  # each hardware variant tracks its own manifests.
+  variant_slug: ""
+  # Default update channel on first boot (no stored user choice yet, i.e. a
+  # fresh flash). The beta-channel builds override this to "Beta" (see
+  # Integrations/ESPHome/beta-channel/) so firmware obtained from the beta
+  # channel keeps tracking it instead of offering a stable "downgrade".
+  firmware_channel_default: "Stable"
+  # Manifest URL bases. Stable = GitHub Pages (main branch builds).
+  # Beta = rolling "beta-fw" pre-release assets (beta branch builds).
+  stable_manifest_base: "https://apolloautomation.github.io/PLT-1"
+  beta_manifest_base: "https://github.com/ApolloAutomation/PLT-1/releases/download/beta-fw"
+  # Per-variant OTA manifest URLs picked by apply_ota_source.
+  ota_stable_manifest: "${stable_manifest_base}/firmware${variant_slug}/manifest.json"
+  ota_beta_manifest: "${beta_manifest_base}/manifest${variant_slug}.json"
+
+esphome:
+  # List form so package merging concatenates with each variant's own on_boot
+  # entries (mapping form would be replaced by the variant's block instead).
+  on_boot:
+    # Point the update entity at the selected channel's manifest.
+    - priority: -100
+      then:
+        - script.execute: apply_ota_source
+    # Re-apply the Bluetooth Proxy switch after all components set up, so BLE
+    # scanning matches the persisted switch (proxy stays off by default).
+    - priority: -300
+      then:
+        - if:
+            condition:
+              switch.is_on: bluetooth_proxy_switch
+            then:
+              - esp32_ble_tracker.start_scan:
+                  continuous: true
+            else:
+              - esp32_ble_tracker.stop_scan:
 
 esp32:
   variant: esp32c3
@@ -9,6 +45,13 @@ esp32:
     advanced:
        assertion_level: SILENT
        enable_lwip_assert: false
+
+esp32_ble_tracker:
+  id: ble_tracker
+  scan_parameters:
+    continuous: true
+
+bluetooth_proxy:
 
 api:
   actions:
@@ -75,6 +118,17 @@ globals:
 
 
 captive_portal:
+
+http_request:
+  verify_ssl: true
+  # GitHub release-asset downloads answer with a redirect carrying a
+  # ~3.6 KB Content-Security-Policy header; each header line must fit
+  # this buffer or the request fails with "HTTP_CLIENT: Out of buffer".
+  buffer_size_rx: 5120
+  # The redirect target is a signed URL with a ~850-char query string; the
+  # follow-up request line must fit the TX buffer or esp_http_client_open
+  # fails with "Out of buffer" before sending anything.
+  buffer_size_tx: 2048
 
 
 i2c:
@@ -339,6 +393,34 @@ button:
     icon: mdi:power-cycle
     name: "ESP Reboot"
 
+  - platform: template
+    name: "Firmware Update"
+    id: update_firmware
+    icon: mdi:cloud-download
+    entity_category: "config"
+    on_press:
+      - logger.log: "Applying firmware update for the selected channel"
+      # OTA download needs the device awake for its whole duration.
+      - lambda: |-
+          id(deep_sleep_1).prevent_deep_sleep();
+      - delay: 3s
+      - script.execute: apply_ota_source
+      - script.wait: apply_ota_source
+      # The manifest fetch runs in its own task; give it a fixed window to land
+      # (update.is_available stays false for same-version switches).
+      - delay: 5s
+      - lambda: id(update_http_request).perform(true);
+      # Only reached if the update did not start (e.g. manifest unreachable).
+      # Re-arm deep sleep unless something else is holding the device awake.
+      - if:
+          condition:
+            and:
+              - switch.is_off: prevent_sleep
+              - binary_sensor.is_off: ota_mode
+          then:
+            - lambda: |-
+                id(deep_sleep_1).allow_deep_sleep();
+
   - platform: factory_reset
     disabled_by_default: True
     name: "Factory Reset ESP"
@@ -365,8 +447,23 @@ switch:
             condition:
               binary_sensor.is_off: ota_mode
             then:
-              - lambda: |- 
+              - lambda: |-
                   id(deep_sleep_1).allow_deep_sleep();
+
+  # Note: on this deep-sleep device the proxy only forwards while the device
+  # is awake - pair it with "Prevent Sleep" to use it continuously.
+  - platform: template
+    name: "Bluetooth Proxy"
+    id: bluetooth_proxy_switch
+    icon: mdi:bluetooth
+    entity_category: "config"
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    on_turn_on:
+      - esp32_ble_tracker.start_scan:
+          continuous: true
+    on_turn_off:
+      - esp32_ble_tracker.stop_scan:
 
 
 text_sensor:
@@ -385,7 +482,35 @@ text_sensor:
     update_interval: never
     entity_category: "diagnostic"
 
+select:
+  - platform: template
+    name: "Firmware Channel"
+    id: firmware_channel
+    icon: mdi:source-branch
+    entity_category: "config"
+    optimistic: true
+    restore_value: true
+    options:
+      - "Stable"
+      - "Beta"
+    initial_option: "${firmware_channel_default}"
+    on_value:
+      then:
+        - script.execute: apply_ota_source
+
 script:
+  - id: apply_ota_source
+    # Sets the OTA manifest URL from the Firmware Channel select (Stable/Beta).
+    # The manifest URLs are per-variant (ota_*_manifest substitutions via
+    # ${variant_slug}) so each hardware variant tracks its own manifests.
+    then:
+      - lambda: |-
+          const bool beta = id(firmware_channel).current_option() == "Beta";
+          std::string url = beta ? "${ota_beta_manifest}" : "${ota_stable_manifest}";
+          ESP_LOGI("firmware", "OTA manifest set to: %s", url.c_str());
+          id(update_http_request).set_source_url(url);
+      - component.update: update_http_request
+
   - id: statusCheck
     then:
       - if:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.7.12.1"
+  version: "26.7.14.1"
   # Firmware variant identity: overridden to "-b" by the PLT-1B images so
   # each hardware variant tracks its own manifests.
   variant_slug: ""
@@ -54,6 +54,7 @@ esp32_ble_tracker:
 bluetooth_proxy:
 
 api:
+  encryption:
   actions:
     - action: play_buzzer
       variables:

--- a/Integrations/ESPHome/PLT-1.yaml
+++ b/Integrations/ESPHome/PLT-1.yaml
@@ -7,7 +7,7 @@ esphome:
     name: "ApolloAutomation.PLT-1"
     version: "${version}"
 
-  min_version: 2025.6.0
+  min_version: 2025.11.0
   on_boot:
     - priority: 800.0
       then:
@@ -58,20 +58,17 @@ ota:
   - platform: http_request
     id: ota_managed
 
-http_request:
-  verify_ssl: true
-
 safe_mode:
 
 update:
   - platform: http_request
-    id: firmware_update
+    id: update_http_request
     name: Firmware Update
     source: https://apolloautomation.github.io/PLT-1/firmware/manifest.json
 
 wifi:
   on_connect:
-    - component.update: firmware_update
+    - component.update: update_http_request
   ap:
     ssid: "Apollo PLT1 Hotspot"
 

--- a/Integrations/ESPHome/PLT-1B.yaml
+++ b/Integrations/ESPHome/PLT-1B.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  variant_slug: "-b"
+
 esphome:
   name: "apollo-plt-1b"
   friendly_name: Apollo PLT-1B
@@ -7,7 +10,7 @@ esphome:
     name: "ApolloAutomation.PLT-1B"
     version: "${version}"
 
-  min_version: 2025.6.0
+  min_version: 2025.11.0
   on_boot:
     - priority: 999.0
       then:
@@ -55,9 +58,6 @@ ota:
   - platform: http_request
     id: ota_managed
 
-http_request:
-  verify_ssl: true
-
 safe_mode:
 
 web_server:
@@ -66,13 +66,13 @@ web_server:
 
 update:
   - platform: http_request
-    id: firmware_update
+    id: update_http_request
     name: Firmware Update
     source: https://apolloautomation.github.io/PLT-1/firmware-b/manifest.json
 
 wifi:
   on_connect:
-    - component.update: firmware_update
+    - component.update: update_http_request
   ap:
     ssid: "Apollo PLT1B Hotspot"
 

--- a/Integrations/ESPHome/PLT-1B_BLE.yaml
+++ b/Integrations/ESPHome/PLT-1B_BLE.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  variant_slug: "-b"
+
 esphome:
   name: "apollo-plt-1bble"
   friendly_name: Apollo PLT-1BBLE
@@ -7,25 +10,27 @@ esphome:
     name: "ApolloAutomation.PLT-1BBLE"
     version: "${version}"
 
-  min_version: 2025.6.0
+  min_version: 2025.11.0
+  # List form so package merging concatenates with Core.yaml's on_boot
+  # entries (mapping form would replace Core's whole list instead).
   on_boot:
-    priority: 500
-    then:
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"
-      - lambda: |-
-          id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
-          id(deep_sleep_1).set_run_duration(90 * 1000);
-      - if:
-          condition:
-            or:
-              - binary_sensor.is_on: ota_mode
-              - switch.is_on: prevent_sleep
-          then:
-             - lambda: |- 
-                ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
-                id(deep_sleep_1).prevent_deep_sleep(); 
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+        - lambda: |-
+            id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
+            id(deep_sleep_1).set_run_duration(90 * 1000);
+        - if:
+            condition:
+              or:
+                - binary_sensor.is_on: ota_mode
+                - switch.is_on: prevent_sleep
+            then:
+              - lambda: |-
+                  ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
+                  id(deep_sleep_1).prevent_deep_sleep();
       
   on_shutdown:
     - light.turn_off: rgb_light
@@ -39,17 +44,20 @@ dashboard_import:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: ${stable_manifest_base}/firmware${variant_slug}/manifest.json
 
 safe_mode:
 
-bluetooth_proxy:
-  active: true
-
-esp32_ble_tracker:
-  scan_parameters:
-    active: false
-
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo PLT1B Hotspot"
 

--- a/Integrations/ESPHome/PLT-1B_Minimal.yaml
+++ b/Integrations/ESPHome/PLT-1B_Minimal.yaml
@@ -1,13 +1,16 @@
+substitutions:
+  variant_slug: "-b"
+
 esphome:
-  name: "apollo-plt-1b-minimal"
-  friendly_name: Apollo PLT-1B Minimal
-  comment: Apollo PLT-1B Minimal
+  name: "apollo-plt-1b"
+  friendly_name: Apollo PLT-1B
+  comment: Apollo PLT-1B
   name_add_mac_suffix: true
   project:
-    name: "ApolloAutomation.PLT-1B_Minimal"
+    name: "ApolloAutomation.PLT-1B"
     version: "${version}"
 
-  min_version: 2025.6.0
+  min_version: 2025.11.0
   on_boot:
     - priority: 999.0
       then:
@@ -49,12 +52,24 @@ improv_serial:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/PLT-1/firmware-b/manifest.json
 
 web_server:
   port: 80
   version: 3
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo PLT1B Hotspot"
 

--- a/Integrations/ESPHome/PLT-1_BLE.yaml
+++ b/Integrations/ESPHome/PLT-1_BLE.yaml
@@ -7,25 +7,27 @@ esphome:
     name: "ApolloAutomation.PLT-1BLE"
     version: "${version}"
 
-  min_version: 2025.6.0
+  min_version: 2025.11.0
+  # List form so package merging concatenates with Core.yaml's on_boot
+  # entries (mapping form would replace Core's whole list instead).
   on_boot:
-    priority: 500
-    then:
-      - text_sensor.template.publish:
-          id: apollo_firmware_version
-          state: "${version}"
-      - lambda: |-
-          id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
-          id(deep_sleep_1).set_run_duration(90 * 1000);
-      - if:
-          condition:
-            or:
-              - binary_sensor.is_on: ota_mode
-              - switch.is_on: prevent_sleep
-          then:
-             - lambda: |- 
-                ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
-                id(deep_sleep_1).prevent_deep_sleep(); 
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+        - lambda: |-
+            id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
+            id(deep_sleep_1).set_run_duration(90 * 1000);
+        - if:
+            condition:
+              or:
+                - binary_sensor.is_on: ota_mode
+                - switch.is_on: prevent_sleep
+            then:
+              - lambda: |-
+                  ESP_LOGW("Apollo", "Preventing Deep Sleep Due To OTA On Boot");
+                  id(deep_sleep_1).prevent_deep_sleep();
       
   on_shutdown:
     - light.turn_off: rgb_light
@@ -38,18 +40,21 @@ dashboard_import:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: ${stable_manifest_base}/firmware${variant_slug}/manifest.json
 
 safe_mode:
 
-bluetooth_proxy:
-  active: true
-
-esp32_ble_tracker:
-  scan_parameters:
-    active: false
-
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo PLT1 Hotspot"
 

--- a/Integrations/ESPHome/PLT-1_Minimal.yaml
+++ b/Integrations/ESPHome/PLT-1_Minimal.yaml
@@ -1,13 +1,13 @@
 esphome:
-  name: "apollo-plt-1-minimal"
-  friendly_name: Apollo PLT-1 Minimal
-  comment: Apollo PLT-1 Minimal
+  name: "apollo-plt-1"
+  friendly_name: Apollo PLT-1
+  comment: Apollo PLT-1
   name_add_mac_suffix: true
   project:
-    name: "ApolloAutomation.PLT-1_Minimal"
+    name: "ApolloAutomation.PLT-1"
     version: "${version}"
 
-  min_version: 2025.6.0
+  min_version: 2025.11.0
   on_boot:
     - priority: 800.0
       then:
@@ -48,12 +48,24 @@ improv_serial:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/PLT-1/firmware/manifest.json
 
 web_server:
   port: 80
   version: 3
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo PLT1 Hotspot"
 

--- a/Integrations/ESPHome/beta-channel/PLT-1B_Minimal.yaml
+++ b/Integrations/ESPHome/beta-channel/PLT-1B_Minimal.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of PLT-1B_Minimal.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use PLT-1B_Minimal.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../PLT-1B_Minimal.yaml

--- a/Integrations/ESPHome/beta-channel/PLT-1_Minimal.yaml
+++ b/Integrations/ESPHome/beta-channel/PLT-1_Minimal.yaml
@@ -1,0 +1,9 @@
+# Beta-channel build of PLT-1_Minimal.yaml: the identical image except the Firmware
+# Channel select defaults to "Beta" on first boot, so firmware obtained from
+# the beta channel keeps tracking it. Built by build-beta.yml only; the
+# stable (GitHub Pages) builds use PLT-1_Minimal.yaml directly.
+substitutions:
+  firmware_channel_default: "Beta"
+
+packages:
+  base: !include ../PLT-1_Minimal.yaml

--- a/static/index.html
+++ b/static/index.html
@@ -84,11 +84,11 @@
       <div class="button-row" style="display: flex; justify-content: center; gap: 20px; align-items: center;">
         <div>
           <p>Non Battery Firmware</p>
-          <esp-web-install-button manifest="./firmware/manifest.json"></esp-web-install-button>
+          <esp-web-install-button manifest="./firmware-factory/manifest.json"></esp-web-install-button>
         </div>
         <div>
           <p>Battery Firmware</p>
-          <esp-web-install-button manifest="./firmware-b/manifest.json"></esp-web-install-button>
+          <esp-web-install-button manifest="./firmware-b-factory/manifest.json"></esp-web-install-button>
         </div>
       </div>
 


### PR DESCRIPTION
Version: 26.7.12.1

Adds:
- Full port of the unified pattern MSR-1 shipped as 26.7.9.1 (ApolloAutomation/MSR-1#100, ApolloAutomation/MSR-1#103, ApolloAutomation/MSR-1#104). `bluetooth_proxy` + `esp32_ble_tracker` now compile into every image; a "Bluetooth Proxy" switch (default off, persisted, re-applied at boot) starts/stops scanning at runtime. On this deep-sleep device the proxy only forwards while awake — pair it with "Prevent Sleep" for continuous use.
- "Firmware Channel" select (Stable/Beta) + `apply_ota_source`: a direct `set_source_url` swap from per-variant `ota_stable_manifest` / `ota_beta_manifest` substitutions (`${variant_slug}` keeps PLT-1 and PLT-1B on their own manifests). The channel is re-applied at boot (`on_boot -100`).
- `http_request` consolidated into Core.yaml with `buffer_size_rx: 5120` / `buffer_size_tx: 2048` — GitHub release redirects overflow the 512-byte defaults (~3.6 KB CSP header line, ~850-char signed query).
- Publishing flip from #69: Minimal images take over Pages `firmware/` + `firmware-b/`; improv images move to `firmware-factory/` + `firmware-b-factory/`; installer page repointed. install.apolloautomation.com needs the matching repoint when this ships to main (mirrors ApolloAutomation/installer#16).
- `beta-channel/` wrappers + build-beta.yml publishing `manifest.json` / `manifest-b.json` to the rolling `beta-fw` pre-release.

Fixes:
- The `_BLE` build split is retired the MSR-1 way: the `_BLE` yamls stay compilable (dashboard_import compat) but lose their own proxy/tracker blocks and their update entities point at the standard manifests — they were never published, so there are no fielded `_BLE` devices to keep on a legacy manifest; self-builders converge onto the unified image.
- `_BLE` variants' `on_boot` converted from mapping to list form so Core's boot entries merge instead of silently replacing the variant's block.
- No pre-OTA BLE disable in the update button — ESPHome's OTA quiesces BLE itself (MSR-1 #103). The button still holds `prevent_deep_sleep()` and re-arms sleep on the not-started path.
- `min_version` 2025.6.0 → 2025.11.0 (the update-system floor set on R_PRO-1).

Breaks:
- Nothing fielded: Minimal images were never published, `_BLE` images were never published. Sleeping devices only see channel changes/updates while awake — `ota_mode` / "Prevent Sleep" (default ON) governs, unchanged.

Supersedes #69.

Checks:
- [ ] Documentation Updated
- [x] Build Number Incremented In Core.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)
